### PR TITLE
Change suggested payload to only be a single value

### DIFF
--- a/mcm/mapper.py
+++ b/mcm/mapper.py
@@ -64,18 +64,23 @@ def build_column_mapping(
 
     """
     probable_mapping = {}
+    thresh = thresh or 0
     for dest in dest_columns:
         result = []
         # We want previous mappings to be at the top of the list.
         if previous_mapping and callable(previous_mapping):
             args = map_args or []
-            result = previous_mapping(dest, *args)
+            mapping = previous_mapping(dest, *args)
+            if mapping:
+                result, conf = mapping
 
-        best_match, conf  = matchers.best_match(dest, raw_columns, top_n=1)[0]
         # Only enter this flow if we haven't already selected a result.
-        thresh = thresh or 0
-        if not result and conf > thresh:
-            result = best_match
+        if not result:
+            best_match, conf  = matchers.best_match(
+                dest, raw_columns, top_n=1
+            )[0]
+            if conf > thresh:
+                result = best_match
 
         probable_mapping[dest] = [result, conf]
 

--- a/mcm/tests/test_mapper.py
+++ b/mcm/tests/test_mapper.py
@@ -95,7 +95,7 @@ class TestMapper(TestCase):
         # relevant results.
         def get_mapping(dest, *args, **kwargs):
             if dest == u'custom_id_1':
-                return u'Tax ID'
+                return [u'Tax ID', 27]
 
         dyn_mapping = mapper.build_column_mapping(
             self.raw_columns,


### PR DESCRIPTION
This represents some of our latest conversations around presenting suggestions to the user during mapping phase: essentially automatically selecting previous selections, or if the threshold is high enough the auto-suggested one.

We'll have to use some front and backend validation to ensure that we don't save duplicates in our mapping.
