### PR TITLE
Fix returning empty lists

### DIFF
--- a/mcm/mapper.py
+++ b/mcm/mapper.py
@@ -29,6 +29,7 @@ def build_column_mapping(
     thresh = thresh or 0
     for raw in raw_columns:
         result = []
+        conf = 0
         # We want previous mappings to be at the top of the list.
         if previous_mapping and callable(previous_mapping):
             args = map_args or []
@@ -43,6 +44,9 @@ def build_column_mapping(
             )[0]
             if conf > thresh:
                 result = best_match
+            else:
+                result = None
+                conf = 0
 
         probable_mapping[raw] = [result, conf]
 

--- a/mcm/tests/test_mapper.py
+++ b/mcm/tests/test_mapper.py
@@ -85,7 +85,6 @@ class TestMapper(TestCase):
 
     def test_build_column_mapping_w_callable(self):
         """Callable result at the begining of the list."""
-
         expected = copy.deepcopy(self.expected)
         # This should be the result of our "previous_mapping" call.
         expected[u'Building ID'] = [u'custom_id_1', 27]
@@ -103,6 +102,42 @@ class TestMapper(TestCase):
         )
 
         self.assertDictEqual(dyn_mapping, expected)
+
+    def test_build_column_mapping_w_null_saved(self):
+        """We handle explicit saves of null, and return those dutifully."""
+        expected = copy.deepcopy(self.expected)
+        # This should be the result of our "previous_mapping" call.
+        expected[u'Building ID'] = [None, 1]
+
+        # Here we pretend that we're doing a query and returning
+        # relevant results.
+        def get_mapping(raw, *args, **kwargs):
+            if raw == u'Building ID':
+                return [None, 1]
+
+        dyn_mapping = mapper.build_column_mapping(
+            self.raw_columns,
+            self.dest_columns,
+            previous_mapping=get_mapping,
+        )
+
+        self.assertDictEqual(dyn_mapping, expected)
+
+    def test_build_column_mapping_w_no_match(self):
+        """We return None if there's no good match."""
+        expected = copy.deepcopy(self.expected)
+        # This should be the result of our "previous_mapping" call.
+        null_result = [None, 0]
+        expected[u'BBL'] = null_result
+
+        dyn_mapping = mapper.build_column_mapping(
+            self.raw_columns,
+            self.dest_columns,
+            thresh=28
+        )
+
+        self.assertDictEqual(dyn_mapping, expected)
+
 
     def test_map_row_dynamic_mapping_with_cleaner(self):
         """Run type-based cleaners on dynamic fields based on reverse-mapping"""


### PR DESCRIPTION
- Our suggested_column_mappings payload was returning empty lists where it should have been returning empty strings. This fixes that and adds more testing.
