### PR TITLE
fix unicode errors during auto-suggest

### DIFF
--- a/mcm/matchers.py
+++ b/mcm/matchers.py
@@ -9,7 +9,10 @@ def best_match(s, categories, top_n=5):
     """Return the top N best matches from your categories."""
     scores = []
     for cat in categories:
-        scores.append((cat, jellyfish.jaro_winkler(s.upper(), cat.upper())))
+        scores.append((cat, jellyfish.jaro_winkler(
+            s.encode('ascii', 'replace').upper(),
+            cat.encode('ascii', 'replace').upper()
+        )))
 
     scores = sorted(scores, key=lambda x: x[1])
     scores = scores[-top_n:]


### PR DESCRIPTION
```
Task seed.tasks.map_row_chunk[e484b1f2-9dbb-4ebb-8fda-859d2e362755] raised exception: UnicodeEncodeError('ascii', u'0619\u20100176', 4, 5, 'ordinal not in range(128)')
Traceback (most recent call last):
  File "/opt/boxen/data/virturalenvs/seed/lib/python2.7/site-packages/celery/task/trace.py", line 233, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/opt/boxen/data/virturalenvs/seed/lib/python2.7/site-packages/celery/task/trace.py", line 420, in __protected_call__
    return self.run(*args, **kwargs)
  File "/Users/alandgraf/code/seed-core/seed/tasks.py", line 510, in map_row_chunk
    **kwargs
  File "/opt/boxen/data/virturalenvs/seed/src/mcm-core/mcm/mapper.py", line 188, in map_row
    apply_func=send_apply_func
  File "/opt/boxen/data/virturalenvs/seed/src/mcm-core/mcm/mapper.py", line 114, in apply_column_value
    cleaned_value = cleaner.clean_value(value, column_name)
  File "/opt/boxen/data/virturalenvs/seed/src/mcm-core/mcm/cleaners.py", line 85, in clean_value
    value = default_cleaner(value)
  File "/opt/boxen/data/virturalenvs/seed/src/mcm-core/mcm/cleaners.py", line 23, in default_cleaner
    if fuzzy_in_set(value.lower(), NONE_SYNONYMS):
  File "/opt/boxen/data/virturalenvs/seed/src/mcm-core/mcm/matchers.py", line 24, in fuzzy_in_set
    column_name, ontology, top_n=1
  File "/opt/boxen/data/virturalenvs/seed/src/mcm-core/mcm/matchers.py", line 12, in best_match
    scores.append((cat, jellyfish.jaro_winkler(s.upper(), cat.upper())))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2010' in position 4: ordinal not in range(128)
```
