### PR TITLE
adds headers (original order)

### DIFF
--- a/mcm/reader.py
+++ b/mcm/reader.py
@@ -131,6 +131,9 @@ class ExcelParser(object):
         """gets the number of columns for the file"""
         return self.sheet.ncols
 
+    def headers(self):
+        return self.sheet.row_values(self.header_row)
+
 
 class CSVParser(object):
     """CSV (.csv) file parser for MCMParser
@@ -211,6 +214,9 @@ class CSVParser(object):
         """gets the number of columns for the file"""
         return len(self.csvreader.unicode_fieldnames)
 
+    def headers(self):
+        return self.csvreader.fieldnames
+
 
 class MCMParser(object):
     """
@@ -286,6 +292,10 @@ class MCMParser(object):
     def num_columns(self):
         """returns the number of columns of the file"""
         return self.reader.num_columns()
+
+    def headers(self):
+        """original order of spreadsheet headers"""
+        return self.reader.headers()
 
 
 def main():

--- a/mcm/reader.py
+++ b/mcm/reader.py
@@ -132,6 +132,7 @@ class ExcelParser(object):
         return self.sheet.ncols
 
     def headers(self):
+        """original ordered list of spreadsheet headers"""
         return self.sheet.row_values(self.header_row)
 
 
@@ -215,6 +216,7 @@ class CSVParser(object):
         return len(self.csvreader.unicode_fieldnames)
 
     def headers(self):
+        """original ordered list of spreadsheet headers"""
         return self.csvreader.fieldnames
 
 
@@ -294,7 +296,7 @@ class MCMParser(object):
         return self.reader.num_columns()
 
     def headers(self):
-        """original order of spreadsheet headers"""
+        """original ordered list of spreadsheet headers"""
         return self.reader.headers()
 
 

--- a/mcm/tests/test_reader.py
+++ b/mcm/tests/test_reader.py
@@ -88,7 +88,7 @@ class TestMCMParserCSV(TestCase):
         self.assertEqual(self.parser.num_columns(), 250)
 
     def test_headers(self):
-        self.maxDiff = None
+        """tests that we can get the original order of headers"""
         self.assertEqual(
             self.parser.headers()[0],
             'Property Id'
@@ -136,7 +136,6 @@ class TestMCMParserXLS(TestCase):
         self.assertEqual(self.parser.num_columns(), 250)
 
     def test_headers(self):
-        self.maxDiff = None
         self.assertEqual(
             self.parser.headers()[0],
             'Property Id'
@@ -184,7 +183,6 @@ class TestMCMParserXLSX(TestCase):
         self.assertEqual(self.parser.num_columns(), 250)
 
     def test_headers(self):
-        self.maxDiff = None
         self.assertEqual(
             self.parser.headers()[0],
             'Property Id'

--- a/mcm/tests/test_reader.py
+++ b/mcm/tests/test_reader.py
@@ -87,6 +87,17 @@ class TestMCMParserCSV(TestCase):
     def test_num_colums(self):
         self.assertEqual(self.parser.num_columns(), 250)
 
+    def test_headers(self):
+        self.maxDiff = None
+        self.assertEqual(
+            self.parser.headers()[0],
+            'Property Id'
+        )
+        self.assertEqual(
+            self.parser.headers()[-1],
+            'Release Date'
+        )
+
 
 class TestMCMParserXLS(TestCase):
     def setUp(self):
@@ -124,6 +135,17 @@ class TestMCMParserXLS(TestCase):
     def test_num_colums(self):
         self.assertEqual(self.parser.num_columns(), 250)
 
+    def test_headers(self):
+        self.maxDiff = None
+        self.assertEqual(
+            self.parser.headers()[0],
+            'Property Id'
+        )
+        self.assertEqual(
+            self.parser.headers()[-1],
+            'Release Date'
+        )
+
 
 class TestMCMParserXLSX(TestCase):
     def setUp(self):
@@ -160,3 +182,14 @@ class TestMCMParserXLSX(TestCase):
 
     def test_num_colums(self):
         self.assertEqual(self.parser.num_columns(), 250)
+
+    def test_headers(self):
+        self.maxDiff = None
+        self.assertEqual(
+            self.parser.headers()[0],
+            'Property Id'
+        )
+        self.assertEqual(
+            self.parser.headers()[-1],
+            'Release Date'
+        )


### PR DESCRIPTION
One main complaint from users is that uploaded data is rearranged randomly. Here we're adding in a call to the reader to get the original order of the column headers so that we can display the data in that order once it's saved to the DB.

